### PR TITLE
Fix color icon in the tray for unread messages

### DIFF
--- a/colors.tdesktop-theme
+++ b/colors.tdesktop-theme
@@ -106,7 +106,7 @@ titleButtonCloseBgOver: cTransparent; // ??? [te]
 titleButtonCloseFgOver: pRed; // ??? [te]
 titleFgActive: pPurple; // Window Title color when active [te]
 titleFg: pComment; // Window Title color
-trayCounterBg: pSelection; // ??? [te]
+trayCounterBg: pRed; // Tray icon counter background for unread messages
 trayCounterBgMute: pBg; // ??? [te]
 trayCounterFg: pFg; // ??? [te]
 trayCounterBgMacInvert: pComment; // ??? [te]


### PR DESCRIPTION
At now theme has wrong color for unread messages in the windows tray
![before](https://user-images.githubusercontent.com/19549758/41533987-79615900-7305-11e8-9cad-eefa3de7aa71.png)

Standard desktop telegram theme has [red color](https://github.com/telegramdesktop/tdesktop/blob/55e56a6788870e6d67d9938eaabdf87f2ebddb17/Telegram/Resources/colors.palette#L122)
`trayCounterBgMute: #888888; // tray icon counter background if all unread messages are muted`

I updated color to **pRed** from current _Color Pallete_
Now it looks like 
![after](https://user-images.githubusercontent.com/19549758/41534104-f996ac60-7305-11e8-9e24-7a31a89d2e04.png)
